### PR TITLE
Fix bug with not starting with numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,11 @@ function generate(options) {
           lines.push(origLines[i]);
         }
         const title = lines.join('').substr(2).trim();
-        res.content += `- [ADR-${token.content.match(/^\d+/m)[0].trim()}](${token.content}) - ${title}\n`
+        const numb = token.content.match(/^\d+/m);
+        if (numb === null || numb === undefined) {
+          continue;
+        }
+        res.content += `- [ADR-${numb[0].trim()}](${token.content}) - ${title}\n`
       }
       res.content = res.content.trim();
       return res;


### PR DESCRIPTION
If a md file that didn't start with a number (eg. template.md) was in the target directory,
the result of the regex is null.
The direct access to the result with index 0 caused null-pointer errors.

This is fixed.