### PR TITLE
fix adr/adr-log#28

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -55,7 +55,8 @@ var adrLogDir = args.d || defaultAdrLogDir;
 
 var defaultAdrLogFile = 'index.md';
 var adrLogFile = args._[0] || adrLogDir + '/' + defaultAdrLogFile;
-var adrLogFileName = require('path').parse(adrLogFile).base;
+var adrLogFileName = path.parse(adrLogFile).base;
+var tocDir = path.dirname(adrLogFile);
 
 console.log("adr log file:", adrLogFile);
 console.log("adr log dir:", adrLogDir);
@@ -78,7 +79,7 @@ if (fs.existsSync(adrLogFile)) {
 } else {
   existingLogString = '<!-- adrlog -->' + os.EOL + os.EOL + '<!-- adrlogstop -->' + os.EOL;
 }
-var newLogString = toc.insertAdrToc(existingLogString, headings, adrLogDir);
+var newLogString = toc.insertAdrToc(existingLogString, headings, {dir: adrLogDir, tocDir});
 
 if (args.i) {
   fs.writeFileSync(adrLogFile, newLogString);

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Architectural Decision Log
+
+This log lists the architectural decisions for adr-log.
+
+<!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->
+
+- [ADR-0000](adr/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+- [ADR-0001](adr/0001-extend-markdown-toc.md) - Extend markdown-toc
+- [ADR-0002](adr/0002-use-console-stamp-as-logging-framework.md) - Use console-stamp as logging framework
+- [ADR-0003](adr/0003-use-release-it-and-github-release-from-changelog-as-release-tooling.md) - Use release-it and github-release-from-changelog for releasing
+- [ADR-0004](adr/0004-filename-as-direct-parameter.md) - Filename as direct parameter
+
+<!-- adrlogstop -->
+
+For new ADRs, please use [template.md](template.md) as basis.
+More information on MADR is available at <https://adr.github.io/madr/>.
+General information about architectural decision records is available at <https://adr.github.io/>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adr-log",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1195,6 +1195,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "snapdragon": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lazy-cache": "^2.0.2",
     "minimist": "^1.2.0",
     "path": "^0.12.7",
-    "remarkable": "^1.7.1"
+    "remarkable": "^1.7.1",
+    "slash": "^3.0.0"
   },
   "devDependencies": {
     "gulp-format-md": "^0.1.11"


### PR DESCRIPTION
# Changelog 
- fix issue: #28
- added slash that should convert windows paths to web/unix paths
- did some code cleanup:
  - [reuse already require module instead of requiring it again](https://github.com/adr/adr-log/pull/29/files#diff-2cce40143051e25f811b56c79d619bf5R58)
  - [delete non used variable](https://github.com/adr/adr-log/pull/29/files#diff-168726dbe96b3ce427e7fedce31bb0bcL48)
  - convert usage of `var` to `const`:
      1. [change](https://github.com/adr/adr-log/pull/29/files#diff-168726dbe96b3ce427e7fedce31bb0bcR7)
  - convert usage of `var` to `let`:
     1. [change](https://github.com/adr/adr-log/pull/29/files#diff-168726dbe96b3ce427e7fedce31bb0bcR61)
    2. [change](https://github.com/adr/adr-log/pull/29/files#diff-168726dbe96b3ce427e7fedce31bb0bcR71)
    3. [change](https://github.com/adr/adr-log/pull/29/files#diff-168726dbe96b3ce427e7fedce31bb0bcR76)

