### PR TITLE
New option `-p` for specify ADR file prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 We refer to [GitHub issues](https://github.com/adr/adr-log/issues) by using `#NUM`.
 
+## [Unreleased, MINOR 2.2.0]
+
+### Added
+
+- New option `-p` - prefix for each ADR file path in log (useful when ADRs are in sub sub directory) 
+
 ## [2.1.3] – 2019-11-15
 
 ### Fixed

--- a/cli.js
+++ b/cli.js
@@ -21,12 +21,13 @@ var path = require('path');
 var args = utils.minimist(process.argv.slice(2), {
   boolean: ['i'],
   string: ['d'],
+  string: ['p'],
   alias: {h: 'help'}
 });
 
-if (!args.d && !args.i && (args._.length==0) || args.h) {
+if (!args.d && !args.i && !args.p && (args._.length==0) || args.h) {
   process.stderr.write([
-    'Usage: adr-log [-d <directory>] [-i] <input>',
+    'Usage: adr-log [-d <directory>] [-i] <input> [-p] <path_prefix>',
     '',
     '  input:  The markdown file to contain the table of contents.',
     '          If no <input> file is specified, an index.md file containing the log is created in the current directory.',
@@ -38,6 +39,9 @@ if (!args.d && !args.i && (args._.length==0) || args.h) {
     '',
     '  -d:     Scans the given <directory> for .md files.',
     '          (Without this flag, the current working directory is chosen as default.)',
+    '',
+    '  -p:     Path prefix for each ADR file path written in log',
+    '          (Default is empty)',
     '',
     '  -h:     Shows how to use this program',
     ''
@@ -52,6 +56,7 @@ if (args.i && args._[0] === '-') {
 
 var defaultAdrLogDir = path.resolve(process.cwd());
 var adrLogDir = args.d || defaultAdrLogDir;
+var adrPathPrefix = args.p || '';
 
 var defaultAdrLogFile = 'index.md';
 var adrLogFile = args._[0] || adrLogDir + '/' + defaultAdrLogFile;
@@ -79,7 +84,7 @@ if (fs.existsSync(adrLogFile)) {
 } else {
   existingLogString = '<!-- adrlog -->' + os.EOL + os.EOL + '<!-- adrlogstop -->' + os.EOL;
 }
-var newLogString = toc.insertAdrToc(existingLogString, headings, {dir: adrLogDir, tocDir});
+var newLogString = toc.insertAdrToc(existingLogString, headings, {pathPrefix: adrPathPrefix, dir: adrLogDir, tocDir});
 
 if (args.i) {
   fs.writeFileSync(adrLogFile, newLogString);

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function generate(options) {
         console.log("title before decimal removal: ", title);
         title = title.replace(/^\d+\. /, '');
         console.log("title after decimal removal:  ", title);
-        res.content += `- [ADR-${numb[0].trim()}](${tokenPath}) - ${title + options.newline}`
+        res.content += `- [ADR-${numb[0].trim()}](${options.pathPrefix}${tokenPath}) - ${title + options.newline}`
       }
       res.content = res.content.trim();
       return res;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adr-log",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1049,9 +1049,9 @@
           "dev": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adr-log",
   "description": "Generate an architectural decision log out of architectural decision records (ADRs).",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "homepage": "https://adr.github.io/adr-log/",
   "author": "Oliver Kopp (http://github.com/koppor/)",
   "conttributors": [


### PR DESCRIPTION
New option `-p` for specify file prefix for each ADR file path in log (useful when ADRs are in sub sub directory)