### PR TITLE
Fix bug where bogus path info is prepended to TOC entries when directory argument doesn't include trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,10 +58,11 @@ function generate(options) {
           continue;
         }
 
-        let content = fs.readFileSync(`${options.dir}/${token.content}`).toString();
+        let contentPath = `${options.dir}/${token.content}`
+        let content = fs.readFileSync(contentPath).toString();
 
         let tokenPath = slash(
-          path.relative(options.tocDir, `${options.dir}${token.content}`)
+          path.relative(options.tocDir, contentPath)
         );
 
         // does the file have front-matter?


### PR DESCRIPTION
I believe this addresses issue #32 

Running `node cli.js -d docs/adr -i` in this repository without this fix yields

```
- [ADR-0000](../adr0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
- [ADR-0001](../adr0001-extend-markdown-toc.md) - Extend markdown-toc
- [ADR-0002](../adr0002-use-console-stamp-as-logging-framework.md) - Use console-stamp as logging framework
- [ADR-0003](../adr0003-use-release-it-and-github-release-from-changelog-as-release-tooling.md) - Use release-it and github-release-from-changelog for releasing
- [ADR-0004](../adr0004-filename-as-direct-parameter.md) - Filename as direct parameter
```

With this fix, no changes are produced, as expected.