### PR TITLE
Improve flexibility in the way ADRs are acquired and indexed

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,7 @@ var path = require('path');
 var args = utils.minimist(process.argv.slice(2), {
   boolean: ['i'],
   string: ['d'],
+  string: ['e'],
   alias: {h: 'help'}
 });
 
@@ -38,6 +39,8 @@ if (!args.d && !args.i && (args._.length==0) || args.h) {
     '',
     '  -d:     Scans the given <directory> for .md files.',
     '          (Without this flag, the current working directory is chosen as default.)',
+    '',
+    '  -e      Exclude any files matching the given <pattern>',
     '',
     '  -h:     Shows how to use this program',
     ''
@@ -62,9 +65,15 @@ console.log("adr log file:", adrLogFile);
 console.log("adr log dir:", adrLogDir);
 
 var headings = '';
-const globPattern = '!(' + adrLogFileName.slice(0,-3) + '*).md';
+const globPattern = '**/*.md';
 console.log("glob pattern:", globPattern);
 var filenames = glob.sync(globPattern, {cwd: adrLogDir});
+filenames = filenames.filter(filename => filename !== adrLogFile.replace(adrLogDir + '/', ''));
+if (args.e) {
+  var excluded = glob.sync(args.e, {cwd: adrLogDir});
+  console.log("excluded: ", excluded);
+  filenames = filenames.filter(filename => !excluded.includes(filename));
+}
 console.log("filenames:", filenames);
 
 // determine log entries


### PR DESCRIPTION
Improves the way ADRs are acquired and indexed in the following ways
- search recursively underneath the given directory
- allow date prefixes as well as number prefixes
- allow specification of `index` or `date` properties in frontmatter
- fallback to auto-numbering for ADRs without filename prefixes or frontmatter
- add -e option to specify glob pattern for files to be excluded