### PR TITLE
Add the ability to change bullet style based on parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 We refer to [GitHub issues](https://github.com/adr/adr-log/issues) by using `#NUM`.
 
+## Unreleased
+
+### Added
+
+- New option `-b` to change the style of bullets (asterisk, dash, plus)
+
 ## [2.2.0] – 2020-10-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install -g adr-log
 ## CLI
 
 ```text
-Usage: adr-log [-d <directory>] [-i] <input>
+Usage: adr-log [-d <directory>] [-i <input>] [-p <path_prefix>]
 
   input:  The markdown file to contain the table of contents.
           If no <input> file is specified, an index.md file containing the log is created in the current directory.
@@ -41,6 +41,15 @@ Usage: adr-log [-d <directory>] [-i] <input>
 
   -d:     Scans the given <directory> for .md files.
           (Without this flag, the current working directory is chosen as default.)
+
+  -e      Exclude any files matching the given <pattern>
+
+  -p:     Path prefix for each ADR file path written in log
+          (Default is empty)
+
+  -b      Change the character used to for bullets
+          Supports: asterisk, dash, plus
+          (Default is asterisk)
 
   -h:     Shows how to use this program
 ```

--- a/cli.js
+++ b/cli.js
@@ -23,12 +23,13 @@ var args = utils.minimist(process.argv.slice(2), {
   string: ['d'],
   string: ['e'],
   string: ['p'],
+  string: ['b'],
   alias: {h: 'help'}
 });
 
 if (!args.d && !args.i && !args.p && (args._.length==0) || args.h) {
   process.stderr.write([
-    'Usage: adr-log [-d <directory>] [-i] <input> [-p] <path_prefix>',
+    'Usage: adr-log [-d <directory>] [-i <input>] [-p <path_prefix>]',
     '',
     '  input:  The markdown file to contain the table of contents.',
     '          If no <input> file is specified, an index.md file containing the log is created in the current directory.',
@@ -42,8 +43,13 @@ if (!args.d && !args.i && !args.p && (args._.length==0) || args.h) {
     '          (Without this flag, the current working directory is chosen as default.)',
     '',
     '  -e      Exclude any files matching the given <pattern>',
+    '',
     '  -p:     Path prefix for each ADR file path written in log',
     '          (Default is empty)',
+    '',
+    '  -b      Change the character used to for bullets',
+    '          Supports: asterisk, dash, plus',
+    '          (Default is asterisk)',
     '',
     '  -h:     Shows how to use this program',
     ''
@@ -59,6 +65,7 @@ if (args.i && args._[0] === '-') {
 var defaultAdrLogDir = path.resolve(process.cwd());
 var adrLogDir = args.d || defaultAdrLogDir;
 var adrPathPrefix = args.p || '';
+var adrBulletStyle = args.b || '';
 
 var defaultAdrLogFile = 'index.md';
 var adrLogFile = args._[0] || adrLogDir + '/' + defaultAdrLogFile;
@@ -92,7 +99,7 @@ if (fs.existsSync(adrLogFile)) {
 } else {
   existingLogString = '<!-- adrlog -->' + os.EOL + os.EOL + '<!-- adrlogstop -->' + os.EOL;
 }
-var newLogString = toc.insertAdrToc(existingLogString, headings, {pathPrefix: adrPathPrefix, dir: adrLogDir, tocDir});
+var newLogString = toc.insertAdrToc(existingLogString, headings, {pathPrefix: adrPathPrefix, dir: adrLogDir, bulletStyle: adrBulletStyle, tocDir});
 
 if (args.i) {
   fs.writeFileSync(adrLogFile, newLogString);

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function generate(options) {
         console.log("title before decimal removal: ", title);
         title = title.replace(/^\d+\. /, '');
         console.log("title after decimal removal:  ", title);
-        res.content += `* [ADR-${index.trim()}](${options.pathPrefix}${tokenPath}) - ${title + options.newline}`
+        res.content += `${options.bulletChar} [ADR-${index.trim()}](${options.pathPrefix}${tokenPath}) - ${title + options.newline}`
       }
       res.content = res.content.trim();
       return res;

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -4,12 +4,21 @@ var toc = require('..');
 var utils = require('./utils');
 const os = require('os');
 
+var defaultAdrBulletStyle = 'asterisk';
+var bulletStyles = Object.freeze({'asterisk': '*', 'plus': '+', 'dash': '-'})
+
 module.exports.insertAdrToc = function(str, tocContent, options) {
   options = options || {};
   if (typeof options === 'string') {
     options = {
       "dir" : options
     }
+  }
+
+  options.bulletChar = bulletStyles[options.bulletStyle]
+
+  if (options.bulletChar === undefined) {
+    options.bulletChar = bulletStyles[defaultAdrBulletStyle]
   }
 
   let newline = utils.determineNewline(str);


### PR DESCRIPTION
New option `-b` to change the style of bullets (asterisk, dash, plus)

## Testing

### Asterisk, Default and Undefined

```shell
node cli.js -d ./docs/adr/ -e 'template.md' -b 'asterisk' #asterisk
node cli.js -d ./docs/adr/ -e 'template.md' #default
node cli.js -d ./docs/adr/ -e 'template.md' -b 'other' #undefined
```

```markdown
# Architectural Decision Log

This log lists the architectural decisions for adr-log.

<!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->

* [ADR-0000](0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
* [ADR-0001](0001-extend-markdown-toc.md) - Extend markdown-toc
* [ADR-0002](0002-use-console-stamp-as-logging-framework.md) - Use console-stamp as logging framework
* [ADR-0003](0003-use-release-it-and-github-release-from-changelog-as-release-tooling.md) - Use release-it and github-release-from-changelog for releasing
* [ADR-0004](0004-filename-as-direct-parameter.md) - Filename as direct parameter

<!-- adrlogstop -->

For new ADRs, please use [template.md](template.md) as basis.
More information on MADR is available at <https://adr.github.io/madr/>.
General information about architectural decision records is available at <https://adr.github.io/>.
```

### Dash

```shell
node cli.js -d ./docs/adr/ -e 'template.md' -b 'dash' 
```

```markdown
# Architectural Decision Log

This log lists the architectural decisions for adr-log.

<!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->

- [ADR-0000](0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
- [ADR-0001](0001-extend-markdown-toc.md) - Extend markdown-toc
- [ADR-0002](0002-use-console-stamp-as-logging-framework.md) - Use console-stamp as logging framework
- [ADR-0003](0003-use-release-it-and-github-release-from-changelog-as-release-tooling.md) - Use release-it and github-release-from-changelog for releasing
- [ADR-0004](0004-filename-as-direct-parameter.md) - Filename as direct parameter

<!-- adrlogstop -->

For new ADRs, please use [template.md](template.md) as basis.
More information on MADR is available at <https://adr.github.io/madr/>.
General information about architectural decision records is available at <https://adr.github.io/>.
```

### Plus 

```shell
node cli.js -d ./docs/adr/ -e 'template.md' -b 'plus'
```

```markdown
# Architectural Decision Log

This log lists the architectural decisions for adr-log.

<!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->

+ [ADR-0000](0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+ [ADR-0001](0001-extend-markdown-toc.md) - Extend markdown-toc
+ [ADR-0002](0002-use-console-stamp-as-logging-framework.md) - Use console-stamp as logging framework
+ [ADR-0003](0003-use-release-it-and-github-release-from-changelog-as-release-tooling.md) - Use release-it and github-release-from-changelog for releasing
+ [ADR-0004](0004-filename-as-direct-parameter.md) - Filename as direct parameter

<!-- adrlogstop -->

For new ADRs, please use [template.md](template.md) as basis.
More information on MADR is available at <https://adr.github.io/madr/>.
General information about architectural decision records is available at <https://adr.github.io/>.
```