### PR TITLE
Add `category`/`-c` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Usage: adr-log [-d <directory>] [-i <input>] [-p <path_prefix>]
   -b      Change the character used to for bullets
           Supports: asterisk, dash, plus
           (Default is asterisk)
+  
+  -c      Add a category for the ADR
+          (Default is empty)
 
   -h:     Shows how to use this program
 ```

--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,7 @@ var args = utils.minimist(process.argv.slice(2), {
   string: ['e'],
   string: ['p'],
   string: ['b'],
-  alias: {h: 'help'}
+  string: ['c'],
 });
 
 if (!args.d && !args.i && !args.p && (args._.length==0) || args.h) {
@@ -51,6 +51,9 @@ if (!args.d && !args.i && !args.p && (args._.length==0) || args.h) {
     '          Supports: asterisk, dash, plus',
     '          (Default is asterisk)',
     '',
+    '  -c      Add a category for the ADR',
+    '          (Default is empty)',
+    '',
     '  -h:     Shows how to use this program',
     ''
   ].join(os.EOL));
@@ -66,6 +69,10 @@ var defaultAdrLogDir = path.resolve(process.cwd());
 var adrLogDir = args.d || defaultAdrLogDir;
 var adrPathPrefix = args.p || '';
 var adrBulletStyle = args.b || '';
+var adrCategory = ''
+if (args.c) {
+  adrCategory += args.c + '-';
+}
 
 var defaultAdrLogFile = 'index.md';
 var adrLogFile = args._[0] || adrLogDir + '/' + defaultAdrLogFile;
@@ -99,7 +106,7 @@ if (fs.existsSync(adrLogFile)) {
 } else {
   existingLogString = '<!-- adrlog -->' + os.EOL + os.EOL + '<!-- adrlogstop -->' + os.EOL;
 }
-var newLogString = toc.insertAdrToc(existingLogString, headings, {pathPrefix: adrPathPrefix, dir: adrLogDir, bulletStyle: adrBulletStyle, tocDir});
+var newLogString = toc.insertAdrToc(existingLogString, headings, { pathPrefix: adrPathPrefix, dir: adrLogDir, bulletStyle: adrBulletStyle, category: adrCategory, tocDir });
 
 if (args.i) {
   fs.writeFileSync(adrLogFile, newLogString);

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function generate(options) {
         console.log("title before decimal removal: ", title);
         title = title.replace(/^\d+\. /, '');
         console.log("title after decimal removal:  ", title);
-        res.content += `${options.bulletChar} [ADR-${index.trim()}](${options.pathPrefix}${tokenPath}) - ${title + options.newline}`
+        res.content += `${options.bulletChar} [ADR-${options.category}${index.trim()}](${options.pathPrefix}${tokenPath}) - ${title + options.newline}`
       }
       res.content = res.content.trim();
       return res;


### PR DESCRIPTION
Add an extra option `category`. As we have different teams making ADRs and to ease communication, we'd like to categorise them.

Adding this option makes that more easy. I've looked at grey-matter, but that didn't work that well within our wiki server.